### PR TITLE
Feat: 비밀번호 재설정

### DIFF
--- a/controller/UserController.js
+++ b/controller/UserController.js
@@ -139,7 +139,7 @@ const signin = (req, res) => {
             }
         } catch (err) {
             return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-                message: err.message,
+                message: '비밀번호 해싱 중 문제가 발생하였습니다.',
             });
         }
     });

--- a/controller/UserController.js
+++ b/controller/UserController.js
@@ -171,7 +171,33 @@ const pwdResetRequest = (req, res) => {
     });
 };
 
-const pwdReset = (req, res) => {};
+const pwdReset = (req, res) => {
+    const { email, password } = req.body;
+
+    const salt = crypto.randomBytes(10).toString('base64');
+    const hashPwd = crypto.pbkdf2Sync(password, salt, 10000, 10, 'sha512').toString('base64');
+
+    const sql = 'update users set password = ?, salt = ? where email = ?';
+    const values = [hashPwd, salt, email];
+
+    conn.query(sql, values, (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                message: '서버 에러',
+            });
+        }
+
+        if (results.affectedRows > 0) {
+            res.status(StatusCodes.OK).json({
+                message: '비밀번호 초기화 성공',
+            });
+        } else {
+            res.status(StatusCodes.BAD_REQUEST).json({
+                message: '비밀번호 초기화 실패',
+            });
+        }
+    });
+};
 
 module.exports = {
     signup,

--- a/controller/UserController.js
+++ b/controller/UserController.js
@@ -56,12 +56,24 @@ const signup = (req, res) => {
     const values = [email, name, hashPwd, salt];
 
     conn.query(sqlSelect, email, (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                message: '서버 에러',
+            });
+        }
+
         if (results.length > 0) {
             res.status(StatusCodes.BAD_REQUEST).json({
                 message: '이미 존재하는 이메일입니다.',
             });
         } else {
             conn.query(sqlInsert, values, (err, results) => {
+                if (err) {
+                    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                        message: '서버 에러',
+                    });
+                }
+
                 if (results.affectedRows > 0) {
                     res.status(StatusCodes.CREATED).json({
                         message: '회원가입 성공',
@@ -83,7 +95,7 @@ const signin = (req, res) => {
     conn.query(sql, email, (err, results) => {
         if (err) {
             return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-                message: err.message,
+                message: '서버 에러',
             });
         }
 
@@ -134,15 +146,39 @@ const signin = (req, res) => {
 };
 
 const pwdResetRequest = (req, res) => {
-    res.json({
-        message: '비밀번호 초기화 요청',
+    const { email } = req.body;
+    const sql = 'select * from users where email = ?';
+
+    conn.query(sql, email, (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                message: '서버 에러',
+            });
+        }
+
+        const user = results[0];
+
+        if (!user) {
+            return res.status(StatusCodes.UNAUTHORIZED).json({
+                message: '해당하는 이메일이 존재하지 않습니다.',
+            });
+        } else {
+            return res.status(StatusCodes.OK).json({
+                message: '이메일 발송 성공',
+                email: email,
+            });
+        }
     });
 };
 
-const pwdReset = (req, res) => {
-    res.json({
-        message: '비밀번호 초기화',
-    });
-};
+const pwdReset = (req, res) => {};
 
-module.exports = { signup, signin, pwdResetRequest, pwdReset, validatesSignup, validatesSignin };
+module.exports = {
+    signup,
+    signin,
+    pwdResetRequest,
+    pwdReset,
+    validatesSignup,
+    validatesSignin,
+    validateEmail,
+};

--- a/routes/users.js
+++ b/routes/users.js
@@ -7,6 +7,7 @@ const {
     pwdReset,
     validatesSignup,
     validatesSignin,
+    validateEmail,
 } = require('../controller/UserController');
 
 router.use(express.json());
@@ -20,8 +21,8 @@ router.post('/signin', validatesSignin, signin);
 router
     .route('/reset')
     // 비밀번호 초기화 요청
-    .post(pwdResetRequest)
+    .post(validateEmail, pwdResetRequest)
     // 비밀번호 초기화
-    .put(pwdReset);
+    .put(validatesSignin, pwdReset);
 
 module.exports = router;


### PR DESCRIPTION
## 작업 사항
1. 비밀번호 재설정 요청 기능 추가
    - 이메일 존재 유무 확인
    - 데이터베이스 이메일 존재 시 해당 이메일 주소 반환
2. 비밀번호 재설정
    - 기존 비밀번호와 변경하려는 새 비밀번호가 같을 시 Bad Request 반환
    - 비밀번호 초기화 시에도 마찬가지로 영문자, 숫자, 특수 문자 각 하나 이상 포함 및 8~16자 사이여야 한다.
    - 변경한 비밀번호도 암호화 후 데이터베이스에 저장
## 차후 수정할 사항
1. 비밀번호 재설정 요청 시 이메일 전송되게 할 예정
2. 비동기 처리로 리팩토링