### PR TITLE
Feat: 회원가입 시 인증코드 입력 받도록 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules/
 .env
 .env.test
 .env.production
+
+# mailer config
+config/senderInfo.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cSpell.words": ["camelcase", "signin"]
+    "cSpell.words": ["camelcase", "openapi", "signin"]
 }

--- a/controller/UserController.js
+++ b/controller/UserController.js
@@ -37,7 +37,16 @@ const signupRequest = async (req, res) => {
     const { email } = req.body;
 
     try {
+        const existedEmail = await getUserByEmail(connection, email);
+
+        if (existedEmail) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: '이미 존재하는 이메일입니다.',
+            });
+        }
+
         await sendAuthCodeEmail(email);
+
         return res.status(StatusCodes.OK).json({
             message: '이메일 발송 성공',
         });
@@ -52,7 +61,56 @@ const signupRequest = async (req, res) => {
 };
 
 const signupConfirm = async (req, res) => {
-    console.log('signupConfirm');
+    const connection = await conn.getConnection();
+
+    const { email, name, password, authCode } = camelcaseKeys(req.body);
+
+    const hashedPwd = await hashPassword(password);
+
+    const sqlInsertUser = 'insert into users (email, name, password) values (?, ?, ?)';
+    const sqlSelectCode = 'select auth_code, expiry from authCode where email = ?';
+    const sqlDeleteCode = 'delete from authCode where email = ?';
+
+    const values = [email, name, hashedPwd];
+
+    try {
+        const [rows] = await connection.query(sqlSelectCode, email);
+
+        if (rows.length > 0) {
+            if (rows[0].auth_code !== authCode) {
+                return res.status(StatusCodes.BAD_REQUEST).json({
+                    message: '인증 코드가 일치하지 않습니다.',
+                });
+            }
+
+            const currentTime = Date.now();
+
+            if (currentTime > rows[0].expiry) {
+                await sendAuthCodeEmail(email);
+                return res.status(StatusCodes.BAD_REQUEST).json({
+                    message: '인증 코드가 만료되었습니다. 새로운 인증 코드를 전송하였습니다.',
+                });
+            }
+
+            await connection.query(sqlInsertUser, values);
+            await connection.query(sqlDeleteCode, email);
+
+            return res.status(StatusCodes.CREATED).json({
+                message: '회원가입 성공',
+            });
+        } else {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: '먼저 이메일 인증을 진행해주세요.',
+            });
+        }
+    } catch (err) {
+        console.log(err);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+            message: '회원가입 중 문제가 발생하였습니다.',
+        });
+    } finally {
+        connection.release();
+    }
 };
 
 const signin = async (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
                 "express-validator": "^7.0.1",
                 "http-status-codes": "^2.3.0",
                 "jsonwebtoken": "^9.0.2",
-                "mysql2": "^3.6.5"
+                "mysql2": "^3.6.5",
+                "nodemailer": "^6.9.8"
             },
             "devDependencies": {
                 "camelcase-keys": "^5.2.0",
@@ -1338,6 +1339,14 @@
                 "encoding": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/nodemailer": {
+            "version": "6.9.8",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.8.tgz",
+            "integrity": "sha512-cfrYUk16e67Ks051i4CntM9kshRYei1/o/Gi8K1d+R34OIs21xdFnW7Pt7EucmVKA0LKtqUGNcjMZ7ehjl49mQ==",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "express-validator": "^7.0.1",
         "http-status-codes": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
-        "mysql2": "^3.6.5"
+        "mysql2": "^3.6.5",
+        "nodemailer": "^6.9.8"
     },
     "scripts": {
         "start": "node ./app.js",

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { signup, signin, pwdResetRequest, pwdReset } = require('../controller/userController');
+const { signupRequest, signin, pwdResetRequest, pwdReset, signupConfirm } = require('../controller/UserController');
 
 const { validatesSignup, validatesSignin, validatesEmail } = require('../middleware/userValidator');
 
@@ -52,7 +52,8 @@ router.use(express.json());
  *                   example: "회원가입 실패"
  */
 
-router.post('/signup', validatesSignup, signup);
+router.post('/signup/request', signupRequest);
+router.post('/signup', validatesSignup, signupConfirm);
 
 /**
  * @swagger

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -1,0 +1,46 @@
+const nodemailer = require('nodemailer');
+const conn = require('../mariadb');
+
+const generateAuthCode = () => {
+    const authCode = Math.random().toString().slice(2, 8);
+    return authCode;
+};
+
+const sendAuthCodeEmail = async (email) => {
+    const connection = await conn.getConnection();
+
+    const EMAIL_USER = process.env.EMAIL_USER;
+    const EMAIL_PASS = process.env.EMAIL_PASS;
+
+    const authCode = generateAuthCode();
+    const expiry = Date.now() + 1000 * 60 * 3;
+
+    const sqlInsert = `insert into authCode (email, auth_code, expiry) values (?, ?, ?)
+     on duplicate key update auth_code = values(auth_code), expiry = values(expiry)`;
+    const values = [email, authCode, expiry];
+
+    const transporter = nodemailer.createTransport({
+        service: 'gmail',
+        auth: {
+            user: EMAIL_USER,
+            pass: EMAIL_PASS,
+        },
+    });
+
+    const mailOptions = {
+        from: EMAIL_USER,
+        to: email,
+        subject: '회원가입 인증 코드',
+        text: `회원가입 인증 코드는 ${authCode}입니다.`,
+    };
+
+    try {
+        await transporter.sendMail(mailOptions);
+        await connection.query(sqlInsert, values);
+    } catch (err) {
+        console.log(err);
+        throw new Error('메일 전송에 실패하였습니다.');
+    }
+};
+
+module.exports = { sendAuthCodeEmail };


### PR DESCRIPTION
## 구현 사항
1. nodemailer 설치
2. 인증코드 관리하는 데이터베이스 테이블 추가 `(authCode)`
3. `/signup/request`
   - 회원 가입 시 인증 코드 전송
   - 이미 가입한 유저일 경우 전송 불가능
   - 정상적으로 인증 코드 전송 시 authCode 테이블에 'email, auth_code'로 추가
   - 인증 코드는 6자리 랜덤 숫자
   - 만약 같은 이메일로 인증 코드 재전송 시 기존 테이블 데이터는 새로 업데이트
4. `/signup`
   - 인증 코드 전송 후 'email, name, password, auth_code'를 body로 함께 보낸다.
   - 인증 코드가 일치하지 않으면 회원가입 불가
   - 인증 코드가 만료되었다면 새로운 인증 코드 재전송
   - 'authCode' 테이블에 입력한 이메일이 없다면 이메일 인증 페이지로 리디렉션(프론트)
## 이메일 인증코드 발송 예시
![스크린샷 2024-01-28 225224](https://github.com/alsrud991026/bookstore-service/assets/108920053/47ab3dac-d2d9-4947-b0fc-4f4ba5eb20ce)

